### PR TITLE
Feat: :alien: helper

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM node:18
 WORKDIR /app
-RUN apk add --no-cache libc6-compat
+
 COPY package*.json ./
+COPY prisma ./prisma/
+
 RUN npm install -g pnpm
 RUN pnpm install
 COPY . .
 RUN pnpm build
+
 EXPOSE 3000
-CMD ["npm", "run", "start"]
+CMD ["pnpm", "start:migrate:prod"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         env_file:
             - .env
         ports:
-            - '5439:5432'
+            - '5432:5432'
         networks:
             - nest_networks
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,12 @@ version: '3'
 services:
     db:
         image: postgres
+        container_name: db
         restart: always
         env_file:
             - .env
         ports:
-            - '5432:5432'
+            - '5439:5432'
         networks:
             - nest_networks
 
@@ -21,6 +22,8 @@ services:
             - '3000:3000'
         networks:
             - nest_networks
+        depends_on:
+            - db
 
 networks:
     nest_networks:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
         "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
         "test:e2e": "jest --config ./test/jest-e2e.json",
         "prisma:studio": "npx prisma studio",
-        "prisma:gen": "npx prisma generate"
+        "prisma:gen": "npx prisma generate",
+        "start:migrate:prod": "prisma migrate deploy && npm run start:prod"
     },
     "dependencies": {
         "@nestjs/common": "^10.0.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,10 +1,10 @@
 datasource db {
   provider = "postgresql"
-  url      = "postgresql://root:root@localhost:5432/search"
+  url      = env("DATABASE_URL")
 }
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
   binaryTargets = ["native", "linux-arm64-openssl-3.0.x"]
 }
 


### PR DESCRIPTION
## 1월 16일 트러블 슈팅
### 변경사항
- 불필요한 코드 & 파일 정리
  - `RUN apk add --no-cache libc6-compat`
  - `.dockerignore` 에 `node_modules` 추가
- 빌드 & 네트워크 잡는 순서
  - prisma migrate은 CMD 내에 위치 `CMD ["pnpm", "start:migrate:prod"]`
  - `depends_on: \n - db` 추가
- env 수정: 
  - `DATABASE_URL=postgresql://root:root@db:5432/search?schema=public`
  - `localhost` 대신 `container_name`을 DNS name으로 사용 